### PR TITLE
[COMPASS-1939] Query Bar says "BSONDate" instead of "ISODate"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -143,9 +143,6 @@ function getFilterSandbox() {
     },
     Date: function(s) {
       return new Date(s);
-    },
-    BSONDate: function(s) {
-      return new Date(s);
     }
   };
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,10 +53,10 @@ const BSON_TO_JS_STRING = {
     return 'MinKey()';
   },
   Date: function(v) {
-    return `BSONDate('${v.toISOString()}')`;
+    return `ISODate('${v.toISOString()}')`;
   },
   ISODate: function(v) {
-    return `BSONDate('${v.toISOString()}')`;
+    return `ISODate('${v.toISOString()}')`;
   },
   RegExp: function(v) {
     var o = '';

--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
     "test": "mocha",
     "ci": "npm run check && npm test"
   },
-  "homepage": "http://github.com/mongodb-js/mongodb-query-parser",
+  "homepage": "https://github.com/mongodb-js/query-parser",
   "repository": {
     "type": "git",
-    "url": "git://github.com/mongodb-js/mongodb-query-parser.git"
+    "url": "git://github.com/mongodb-js/query-parser.git"
   },
   "bugs": {
-    "url": "git://github.com/mongodb-js/mongodb-query-parser.git/issues"
+    "url": "https://github.com/mongodb-js/query-parser/issues"
   },
   "dependencies": {
     "bson": "^1.0.4",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -44,12 +44,6 @@ describe('mongodb-query-parser', function() {
         });
       });
 
-      it('should support BSONDate', function() {
-        assert.deepEqual(convert('BSONDate("2017-01-01T12:35:31.000Z")'), {
-          $date: '2017-01-01T12:35:31.000Z'
-        });
-      });
-
       it('should support Date', function() {
         assert.deepEqual(convert('Date("2017-01-01T12:35:31.000Z")'), {
           $date: '2017-01-01T12:35:31.000Z'
@@ -216,6 +210,22 @@ describe('mongodb-query-parser', function() {
       it('correctly replaces nested tabs with single spaces', function() {
         var stringified = parser.stringify(query);
         assert.equal(stringified, '{coordinates: {$geoWithin: { $centerSphere: [ [ -79, 28 ], 0.04 ]}}}');
+      });
+    });
+
+    context('when providing a Date', function() {
+      it('correctly converts to an ISODate', function() {
+        var res = parser.parseFilter("{test: Date('2017-01-01T12:35:31.000Z')}");
+        var stringified = parser.stringify(res);
+        assert.equal(stringified, "{test: ISODate('2017-01-01T12:35:31.000Z')}");
+      });
+    });
+
+    context('when providing an ISODate', function() {
+      it('correctly converts to an ISODate', function() {
+        var res = parser.parseFilter("{test: ISODate('2017-01-01T12:35:31.000Z')}");
+        var stringified = parser.stringify(res);
+        assert.equal(stringified, "{test: ISODate('2017-01-01T12:35:31.000Z')}");
       });
     });
   });


### PR DESCRIPTION
# Reported Issue
When a date is selected for filtering in the schema view, range or otherwise, the query bar uses an object called "BSONDate" – the (probably) intended Mongo shell object would be "ISODate".

__Expected Behaviour:__
Mapping a Date to a JS String, the returned string representation should be `ISODate`.

__Actual Behaviour:__
Mapping a Date to a JS String, the returned string representation is `BSONDate`.

# Misc
Also fixed incorrect Git repo url in `package.json` for this NPM package.