### PR TITLE
NumberInt support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,6 +46,9 @@ const BSON_TO_JS_STRING = {
   Decimal128: function(v) {
     return `NumberDecimal('${v.toString()}')`;
   },
+  Int32: function(v) {
+    return `NumberInt{'${v.toString()}')`;
+  },
   MaxKey: function() {
     return 'MaxKey()';
   },
@@ -126,6 +129,9 @@ function getFilterSandbox() {
     },
     Double: bson.Double,
     Int32: bson.Int32,
+    NumberInt: function(s) {
+      return parseInt(s, 10);
+    },
     Long: bson.Long,
     NumberLong: function(v) {
       return bson.Long.fromNumber(v);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -137,6 +137,14 @@ describe('mongodb-query-parser', function() {
         });
       });
 
+      it('should support NumberInt', function() {
+        assert.deepEqual(convert('NumberInt("1234567890")'), 1234567890);
+      });
+
+      it('should support NumberInt with number', function() {
+        assert.deepEqual(convert('NumberInt(1234567890)'), 1234567890);
+      });
+
       it('should support NumberDecimal', function() {
         assert.deepEqual(convert('NumberDecimal("10.99")'), {
           $numberDecimal: '10.99'


### PR DESCRIPTION
NumberInt is included in the shell as well as the documentation: https://docs.mongodb.com/manual/core/shell-types/#numberint. Just returns the integer and not the BSON object.

~TODO: Does `new NumberInt(1)` need to be supported?~