### PR TITLE
Remove core-js global from execution context

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -122,7 +122,9 @@ const FILTER_SANDBOX = {
   }
 };
 
+const CORE_JS_GLOBAL = '__core-js_shared__';
 const SANDBOX = new SaferEval(FILTER_SANDBOX);
+delete SANDBOX._context[CORE_JS_GLOBAL];
 
 function isEmpty(input) {
   const s = _.trim(input);


### PR DESCRIPTION
This removes the `__core-js_shared__` variable from the execution context of the query, since we don't need that functionality in that context anyways. This does not affect the scope outside the execution context as it's copied, and you can see it still remains on the global context.

<img width="279" alt="screenshot 2019-02-06 at 15 08 17" src="https://user-images.githubusercontent.com/9030/52347135-85e25200-2a21-11e9-93d4-e7d18042170f.png">
