### PR TITLE
feat: Upgrade mongodb-language-model to v1.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2533,9 +2533,9 @@
       }
     },
     "mongodb-language-model": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/mongodb-language-model/-/mongodb-language-model-1.3.0.tgz",
-      "integrity": "sha512-Sl2aR66C/JxUzC/KX0itD68das6U4D71v9/VeON3vVLuCU/EyXnqZ18JePvEXYVYFQVOVB9ui+CNxn08oAHhDA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mongodb-language-model/-/mongodb-language-model-1.4.1.tgz",
+      "integrity": "sha512-uVeuKvLE9vADOz1TdxRPKLP6ln1/vS6snV3HHCjx6u3uF5uFVh99GLZs8vxbUB0AQp71CZz5ABOVj7VDg584xw==",
       "requires": {
         "bson": "^1.0.1",
         "debug": "^2.2.0",
@@ -2543,11 +2543,6 @@
         "pegjs": "^0.10.0"
       },
       "dependencies": {
-        "bson": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.6.tgz",
-          "integrity": "sha512-D8zmlb46xfuK2gGvKmUjIklQEouN2nQ0LEHHeZ/NoHM2LDiMk2EYzZ5Ntw/Urk+bgMDosOZxaRzXxvhI5TcAVQ=="
-        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lodash": "^4.17.4",
     "lru-cache": "^4.1.1",
     "mongodb-extended-json": "^1.10.0",
-    "mongodb-language-model": "^1.3.0",
+    "mongodb-language-model": "^1.4.1",
     "ms": "^2.0.0",
     "safer-eval": "^1.3.0"
   },


### PR DESCRIPTION
This PR upgrades the `mongodb-language-model` to version `1.4.1` which adds support for the following geo operators:

- [`$geoIntersects`](https://docs.mongodb.com/manual/reference/operator/query/geoIntersects/)
- [`$near`](https://docs.mongodb.com/manual/reference/operator/query/near/)
- [`$nearSphere`](https://docs.mongodb.com/manual/reference/operator/query/nearSphere/)

The update also adds some minor improvements to validating all geo operators.
See this [pull request](https://github.com/mongodb-js/mongodb-language-model/pull/11) for more information.