### PR TITLE
fix: use strict mode

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,5 +2,8 @@
   "extends": ["mongodb-js/node"],
   "env": {
     "es6": true
+  },
+  "rules": {
+    "strict": "off"
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const EJSON = require('mongodb-extended-json');
 const bson = require('bson');
 const ms = require('ms');
@@ -142,6 +144,7 @@ function isNumberValid(input) {
 }
 
 function executeJavascript(input) {
+  'use strict';
   return SANDBOX.runInContext(input);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3231,9 +3231,9 @@
       "dev": true
     },
     "safer-eval": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/safer-eval/-/safer-eval-1.3.0.tgz",
-      "integrity": "sha512-4qkBS8VzJatFR7F0eZfKoJyjqo43jY1jBvRhB5WXM0eJNjx9fiSmph5NApJefqKqpASKWPfaIJCJMMeWePSzfw==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/safer-eval/-/safer-eval-1.3.5.tgz",
+      "integrity": "sha512-BJ//K2Y+EgCbOHEsDGS5YahYBcYy7JcFpKDo2ba5t4MnOGHYtk7HvQkcxTDFvjQvJ0CRcdas/PyF+gTTCay+3w==",
       "requires": {
         "clones": "^1.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "mongodb-extended-json": "^1.10.0",
     "mongodb-language-model": "^1.4.2",
     "ms": "^2.0.0",
-    "safer-eval": "^1.3.0"
+    "safer-eval": "^1.3.5"
   },
   "devDependencies": {
     "eslint-config-mongodb-js": "^3.0.1",


### PR DESCRIPTION
A sandbox breakout in safer-eval has been reported which can be
exploited when a CommonJs module has not been set to strict mode.

Please check https://github.com/commenthol/safer-eval/pull/7.
