### PR TITLE
fix: Correct handling for Double and Symbol

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,7 +43,7 @@ const FILTER_SANDBOX = {
     return bson.Decimal128.fromString(s);
   },
   Double: function(s) {
-    return bson.Double.fromString(s);
+    return new bson.Double(s);
   },
   Int32: function(i) {
     return new bson.Int32(i);
@@ -76,7 +76,7 @@ const FILTER_SANDBOX = {
     return new bson.ObjectID(i);
   },
   Symbol: function(i) {
-    return new bson.Symbol(i);
+    return new bson.BSONSymbol(i);
   },
   Timestamp: function(low, high) {
     return new bson.Timestamp(low, high);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -225,6 +225,14 @@ describe('mongodb-query-parser', function() {
       it('should support MaxKey', function() {
         assert.deepEqual(convert('MaxKey()'), { $maxKey: 1 });
       });
+
+      it('should support double', function() {
+        assert.deepEqual(convert('Double(13.5)'), 13.5);
+      });
+
+      it('should support Symbol', function() {
+        assert.deepEqual(convert('Symbol("symbol")'), 'symbol');
+      });
     });
   });
 


### PR DESCRIPTION
As part of the upgrade to v4, there were breaking changes in Symbol, because it collides with the `Symbol` primitive datatype.

`Double` also doesn't have a 'fromString' primitive, so needs to use the constructor instead.

I've also added tests for both of these cases.