### PR TITLE
fix: Replace safe-eval with ejson-shell-parser

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,76 @@
+Migration Guide
+===============
+
+MongoDB Query Parser will attempt to minimise API changes between major versions. However, as part of our process to constantly improve security and keep packages up to date, backwards breaking changes can and will occur.
+
+This is a guide to help you make the switch when this happens.
+
+
+Table Of Contents
+-----------------
+
+- [Migrating from 1.0 to 2.0](#migrating-from-10-to-20)
+
+Migrating from 1.0 to 2.0
+-------------------------
+
+This major version includes two big changes:
+- [Updating the version of BSON from v1 to v4](#JS-BSON-breaking-changes)
+- [Changing what types of MQL expressions are allowed in the query parser](#restricting-MQL-expressions)
+
+### JS-BSON Breaking Changes
+
+Please refer to [the list of BSON changes](https://github.com/mongodb/js-bson/blob/master/HISTORY.md), as well as the [upgrade documentation for v4](https://github.com/mongodb/js-bson/blob/master/docs/upgrade-to-v4.md) for more information, but breaking changes that have occurred as part of this upgrade are:
+
+- **`ObjectId`** will now throw TypeErrors instead of silently erroring with invalid input
+- **`Symbol`** has now been renamed to **`BSONSymbol`** as it was conflicting with the ES6 **`Symbol`** type
+- BSON-JS now relies on Node.js v6 or above, and uses ES2015 features in non-transpiled code
+- All BSON types are now ES6 Classes
+- Long is now backed by `Long.js`
+
+### Restricting MQL expressions
+
+MongoDB Query Parser was making use of [`safer-eval`](https://www.npmjs.com/package/safer-eval) to parse difficult queries, which has been removed as this dependency is insecure.
+
+We've replaced this dependency with [`ejson-shell-parser`](https://github.com/mongodb-js/ejson-shell-parser), which instead walks the AST of the query, and only attempts to evaluate the query if it considered safe and well-formed.
+
+Because of this change, some queries that would validate are no longer valid.
+
+Expressions that will now **fail** include:
+- Function declarations (both `function` and lambdas)
+- Ternary syntax (`y > 5 ? 'yes' : 'no'`)
+- Comma syntax (`const a = 5, 3`)
+- Variable assignment (`{ a: (c = 5, c)}`)
+
+As a result, queries like this will no longer be accepted as valid input:
+```javascript
+{
+  ternary: true ? 2 : 3,
+  commaOperator: ("doesn't work", "as users expect"),
+  functionDeclaration: (function(d) { return d.setMonth(0) })(new Date()),
+  variableAssignment: (d = new Date(), d.setDate(1), d),
+}
+```
+
+However, we now officially support these use-cases:
+- Simple expressions (`+`, `-`, `/`, `!` etc)
+- Method from Math (excluding `random`)
+- Methods on Date (including `.now()`)
+- Comments (both `//` and `/* */`)
+
+This means you can build an MQL expression like so:
+```javascript
+{
+  // Calculates the day for the current year (Jan 1 = 1, Feb 1 = 32)
+  dayOfYear: Math.round((new Date().setHours(23) - new Date(new Date().getFullYear(), 0, 1, 0, 0, 0))/1000/60/60/24),
+  now: Date.now(),
+  symbol: BSONSymbol('Example Symbol')
+}
+```
+
+As part of this change, error messages that are produced will be slightly different. While it'll still throw a `SyntaxError`, we now return the coordinates of the incorrect token, instead of just what token was incorrect.
+
+```javascript
+eval('({a: )') // SyntaxError: Unexpected token ')'
+parseProject('({a: )') // SyntaxError: Unexpected token (1:5)
+```

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ parser.detect(queryAsJSON);
 // >>> `json`
 ```
 
+## Migrations
+
+We aim to not have any API breaking changes in this library as we consider it stable, but breakages may occur whenever we upgrade a core dependency or perform a major refactor.
+
+We have a [migration guide](MIGRATION.md) which covers what to look out for between releases.
+
 ## Related
 
 - [`mongodb-language-model`](https://github.com/mongodb-js/mongodb-language-model) Work with rich AST's of MongoDB queries

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,9 +2,8 @@
 
 const EJSON = require('mongodb-extended-json');
 const stringify = require('./stringify');
-const bson = require('bson');
 const ms = require('ms');
-const { SaferEval } = require('safer-eval');
+const { default: ejsonParse } = require('ejson-shell-parser');
 const _ = require('lodash');
 const queryLanguage = require('mongodb-language-model');
 const debug = require('debug')('mongodb-query-parser');
@@ -18,80 +17,6 @@ const DEFAULT_PROJECT = null;
 const DEFAULT_COLLATION = null;
 const DEFAULT_MAX_TIME_MS = ms('5 seconds');
 const QUERY_PROPERTIES = ['filter', 'project', 'sort', 'skip', 'limit'];
-
-const FILTER_SANDBOX = {
-  RegExp: RegExp,
-  Binary: function(buffer, subType) {
-    return new bson.Binary(buffer, subType);
-  },
-  BinData: function(t, d) {
-    return new bson.Binary(Buffer.from(d, 'base64'), t);
-  },
-  UUID: function(u) {
-    return new bson.Binary(Buffer.from(u.replace(/-/g, ''), 'hex'), 4);
-  },
-  Code: function(c, s) {
-    return new bson.Code(c, s);
-  },
-  DBRef: function(collection, oid, db, fields) {
-    return new bson.DBRef(collection, oid, db, fields);
-  },
-  Decimal128: function(s) {
-    return bson.Decimal128.fromString(s);
-  },
-  NumberDecimal: function(s) {
-    return bson.Decimal128.fromString(s);
-  },
-  Double: function(s) {
-    return bson.Double.fromString(s);
-  },
-  Int32: function(i) {
-    return new bson.Int32(i);
-  },
-  NumberInt: function(s) {
-    return parseInt(s, 10);
-  },
-  Long: function(low, high) {
-    return new bson.Long(low, high);
-  },
-  NumberLong: function(v) {
-    return bson.Long.fromNumber(v);
-  },
-  Int64: function(i) {
-    return bson.Long.fromNumber(i);
-  },
-  Map: function(arr) {
-    return new bson.Map(arr);
-  },
-  MaxKey: function() {
-    return new bson.MaxKey();
-  },
-  MinKey: function() {
-    return new bson.MinKey();
-  },
-  ObjectID: function(i) {
-    return new bson.ObjectID(i);
-  },
-  ObjectId: function(i) {
-    return new bson.ObjectID(i);
-  },
-  Symbol: function(i) {
-    return new bson.Symbol(i);
-  },
-  Timestamp: function(low, high) {
-    return new bson.Timestamp(low, high);
-  },
-  ISODate: function(s) {
-    return s === undefined ? new Date() : new Date(s);
-  },
-  Date: function(s) {
-    return s === undefined ? new Date() : new Date(s);
-  }
-};
-
-const CORE_JS_GLOBAL = '__core-js_shared__';
-const SANDBOX = new SaferEval(FILTER_SANDBOX);
-delete SANDBOX._context[CORE_JS_GLOBAL];
 
 function isEmpty(input) {
   const s = _.trim(input);
@@ -108,28 +33,20 @@ function isNumberValid(input) {
   return /^\d+$/.test(input) ? parseInt(input, 10) : false;
 }
 
-function executeJavascript(input) {
-  'use strict';
-  if (input.indexOf('clearImmediate.constructor') > -1) {
-    throw new TypeError('Not allowed to breakout');
-  }
-  return SANDBOX.runInContext(input);
-}
-
 function parseProject(input) {
-  return executeJavascript(input);
+  return ejsonParse(input, { mode: 'loose' });
 }
 
 function parseCollation(input) {
-  return executeJavascript(input);
+  return ejsonParse(input, { mode: 'loose' });
 }
 
 function parseSort(input) {
-  return executeJavascript(input);
+  return ejsonParse(input, { mode: 'loose' });
 }
 
 function parseFilter(input) {
-  return executeJavascript(input);
+  return ejsonParse(input, { mode: 'loose' });
 }
 
 module.exports = function(filter, project = DEFAULT_PROJECT) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb-query-parser",
-  "version": "1.5.0",
+  "version": "1.6.0-rc.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -544,11 +544,6 @@
         }
       }
     },
-    "clones": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/clones/-/clones-1.2.0.tgz",
-      "integrity": "sha512-FXDYw4TjR8wgPZYui2LeTqWh1BLpfQ8lB6upMtlpDF6WlOOxghmTTxWyngdKTgozqBgKnHbTVwTE+hOHqAykuQ=="
-    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -790,6 +785,21 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+    },
+    "ejson-shell-parser": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/ejson-shell-parser/-/ejson-shell-parser-0.0.2.tgz",
+      "integrity": "sha512-86NVl8AP2sDF43LHkPQCUCbER02Dyg3TqTAJ8OHk4lmSdKxD+wG1XRCatfKnLEU+HhFxSACLmHPNeqdRzaDtlw==",
+      "requires": {
+        "acorn": "^7.1.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
+        }
+      }
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -2487,14 +2497,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
-    },
-    "safer-eval": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/safer-eval/-/safer-eval-1.3.6.tgz",
-      "integrity": "sha512-DN9tBsZgtUOHODzSfO1nGCLhZtxc7Qq/d8/2SNxQZ9muYXZspSh1fO7HOsrf4lcelBNviAJLCxB/ggmG+jV1aw==",
-      "requires": {
-        "clones": "^1.2.0"
-      }
     },
     "semver": {
       "version": "5.7.1",

--- a/package.json
+++ b/package.json
@@ -17,14 +17,14 @@
   "dependencies": {
     "bson": "^4.0.3",
     "debug": "^4.1.1",
+    "ejson-shell-parser": "0.0.2",
     "is-json": "^2.0.1",
     "javascript-stringify": "^2.0.1",
     "lodash": "^4.17.15",
     "lru-cache": "^5.1.1",
     "mongodb-extended-json": "^1.10.2",
     "mongodb-language-model": "^1.6.0",
-    "ms": "^2.1.2",
-    "safer-eval": "^1.3.6"
+    "ms": "^2.1.2"
   },
   "devDependencies": {
     "eslint-config-mongodb-js": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mongodb-query-parser",
   "description": "Parse MongoDB queries",
-  "version": "1.5.0",
+  "version": "1.6.0-rc.0",
   "scripts": {
     "check": "mongodb-js-precommit",
     "test": "mocha"


### PR DESCRIPTION
In the replacement of `safe-eval` with `ejson-shell-parser`, we have now restricted the types of query we could parse before.

We are currently allowing:
- Simple expressions (`+`, `-`, `/`, `!` etc)
- Method from Math (excluding `random`)
- Methods on Date (including `.now()`)
- Comments (both `//` and `/* */`)

Queries that contain the following are disallowed:
- Function declarations (both `function` and lambdas)
- Ternary syntax (`y > 5 ? 'yes' : 'no'`)
- Comma syntax (`const a = 5, 3`)

These are uncommon and are likely mistakes, so this should break only a small number of queries.