### PR TITLE
COMPASS-4355: fix NumberLong > MAX_SAFE_INTEGER

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -807,17 +807,17 @@
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
     "ejson-shell-parser": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/ejson-shell-parser/-/ejson-shell-parser-0.0.2.tgz",
-      "integrity": "sha512-86NVl8AP2sDF43LHkPQCUCbER02Dyg3TqTAJ8OHk4lmSdKxD+wG1XRCatfKnLEU+HhFxSACLmHPNeqdRzaDtlw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ejson-shell-parser/-/ejson-shell-parser-1.0.2.tgz",
+      "integrity": "sha512-cXuXDWSrwsNovV8d1wNDvCifiqsj8vk1EyfusI5pWMTvTSVb195z2GMBQ6bgeoVv0or7yCV6aokLBU2aOIWwog==",
       "requires": {
-        "acorn": "^7.1.0"
+        "acorn": "^7.4.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+          "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "bson": "^4.0.3",
     "debug": "^4.1.1",
-    "ejson-shell-parser": "0.0.2",
+    "ejson-shell-parser": "^1.0.2",
     "is-json": "^2.0.1",
     "javascript-stringify": "^2.0.1",
     "lodash": "^4.17.15",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -192,6 +192,12 @@ describe('mongodb-query-parser', function() {
         });
       });
 
+      it('should support NumberLong > MAX_SAFE_INTEGER', function() {
+        assert.deepEqual(convert('NumberLong("345678654321234552")'), {
+          $numberLong: '345678654321234552'
+        });
+      });
+
       it('should support new NumberLong', function() {
         assert.deepEqual(convert('new NumberLong("1234567890")'), {
           $numberLong: '1234567890'


### PR DESCRIPTION
Bumps `ejson-shell-parser` to a version that parses correctly NumberLong > MAX_SAFE_INTEGER.