### PR TITLE
feat: Ease project values validation, but make sure that only documents can be used COMPASS-4644

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -138,8 +138,16 @@ module.exports.isCollationValid = function(input) {
   }
 };
 
-function isValueOkforProject(val) {
-  return (_.isNumber(val) && (val === 0 || val === 1)) || _.isObject(val);
+function isValueOkForProject() {
+  /**
+   * Since server 4.4, project in find queries supports everything that
+   * aggregations $project supports (which is basically anything at all) so we
+   * effectively allow everything as a project value and keep this method for
+   * the context
+   *
+   * @see {@link https://docs.mongodb.com/manual/release-notes/4.4/#projection}
+   */
+  return true;
 }
 
 module.exports.parseProject = function(input) {
@@ -162,10 +170,17 @@ module.exports.isProjectValid = function(input) {
 
   try {
     const parsed = parseProject(input);
-    if (!_.every(parsed, isValueOkforProject)) {
+
+    if (!_.isObject(parsed)) {
+      debug('Project "%s" is invalid. Only documents are allowed', input);
+      return false;
+    }
+
+    if (!_.every(parsed, isValueOkForProject)) {
       debug('Project "%s" is invalid bc of its values', input);
       return false;
     }
+
     return parsed;
   } catch (e) {
     debug('Project "%s" is invalid', input, e);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -383,10 +383,18 @@ describe('mongodb-query-parser', function() {
         comments: { $slice: -1 }
       });
     });
-    it('should detect invalid project strings', function() {
-      assert.equal(parser.isProjectValid('{_id: "a"}'), false);
-      assert.equal(parser.isProjectValid('{_id: "1"}'), false);
+    it('should allow any project strings', function() {
+      assert.deepEqual(parser.isProjectValid('{_id: "a"}'), {_id: 'a'});
+      assert.deepEqual(parser.isProjectValid('{_id: "1"}'), { _id: '1' });
+    });
+    it('should reject broken project strings', () => {
       assert.equal(parser.isProjectValid('{grabage'), false);
+    });
+    it('should reject non object project values', () => {
+      assert.equal(parser.isProjectValid('true'), false);
+      assert.equal(parser.isProjectValid('123'), false);
+      assert.equal(parser.isProjectValid('"something"'), false);
+      assert.equal(parser.isProjectValid('null'), false);
     });
   });
 
@@ -405,7 +413,7 @@ describe('mongodb-query-parser', function() {
         { locale: 'en_US', strength: 1 }
       );
     });
-    it('should detect invalid project strings', function() {
+    it('should detect invalid collation strings', function() {
       assert.equal(parser.isCollationValid('{invalid: "simple"}'), false);
       assert.equal(parser.isCollationValid('{locale: ""}'), false);
       assert.equal(parser.isCollationValid('{locale: "invalid"}'), false);


### PR DESCRIPTION
This PR makes project values validation less strict (but adds validation that project is actually an document) to follow server 4.4 implementation