### PR TITLE
refactor(sort): Allow arrays in sort query option COMPASS-4258

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -173,8 +173,19 @@ module.exports.isProjectValid = function(input) {
   }
 };
 
-function isValueOkforSort(val) {
-  return _.isNumber(val) && (val === 1 || val === -1);
+const ALLOWED_SORT_VALUES = [1, -1, 'asc', 'desc'];
+
+function isValueOkForSortDocument(val) {
+  return _.includes(ALLOWED_SORT_VALUES, val) || (_.isObject(val) && val.$meta);
+}
+
+function isValueOkForSortArray(val) {
+  return (
+    _.isArray(val) &&
+    val.length === 2 &&
+    _.isString(val[0]) &&
+    isValueOkForSortDocument(val[1])
+  );
 }
 
 module.exports.parseSort = function(input) {
@@ -197,11 +208,21 @@ module.exports.isSortValid = function(input) {
 
   try {
     const parsed = parseSort(input);
-    if (!_.every(parsed, isValueOkforSort)) {
-      debug('Sort "%s" is invalid bc of its values', input);
-      return false;
+
+    if (_.isArray(parsed) && _.every(parsed, isValueOkForSortArray)) {
+      return parsed;
     }
-    return parsed;
+
+    if (
+      _.isObject(parsed) &&
+      !_.isArray(parsed) &&
+      _.every(parsed, isValueOkForSortDocument)
+    ) {
+      return parsed;
+    }
+
+    debug('Sort "%s" is invalid bc of its values', input);
+    return false;
   } catch (e) {
     debug('Sort "%s" is invalid', input, e);
     return false;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -421,10 +421,27 @@ describe('mongodb-query-parser', function() {
     it('should work', function() {
       assert.deepEqual(parser.parseSort('{_id: 1}'), { _id: 1 });
       assert.deepEqual(parser.parseSort('{_id: -1}'), { _id: -1 });
-
+    });
+    it('should allow objects and arrays as values', () => {
+      assert.deepEqual(parser.isSortValid('{_id: 1}'), { _id: 1 });
+      assert.deepEqual(parser.isSortValid('{_id: -1}'), { _id: -1 });
+      assert.deepEqual(parser.isSortValid('{_id: "asc"}'), { _id: 'asc' });
+      assert.deepEqual(parser.isSortValid('{_id: "desc"}'), { _id: 'desc' });
+      assert.deepEqual(
+        parser.isSortValid('{ score: { $meta: "textScore" } }'),
+        { score: { $meta: 'textScore' } }
+      );
+      assert.deepEqual(parser.isSortValid('[["123", -1]]'), [['123', -1]]);
+      assert.deepEqual(parser.isSortValid('[["bar", 1]]'), [['bar', 1]]);
+    });
+    it('should reject unsupported sort values', () => {
       assert.equal(parser.isSortValid('{_id: "a"}'), false);
       assert.equal(parser.isSortValid('{_id: "1"}'), false);
       assert.equal(parser.isSortValid('{grabage'), false);
+      assert.equal(parser.isSortValid('[1]'), false);
+      assert.equal(parser.isSortValid('["foo"]'), false);
+      assert.equal(parser.isSortValid('[["foo", "bar"]]'), false);
+      assert.equal(parser.isSortValid('[[123, -1]]'), false);
     });
   });
 


### PR DESCRIPTION
This PR changes sort validation to align more with [driver behavior](http://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#find) and allowed server values