### PR TITLE
fix(sort): Always parse sort before validating so null and undefined can be properly handled

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -217,12 +217,12 @@ module.exports.parseSort = function(input) {
  * @return {Boolean|Object} false if not valid, otherwise the cleaned-up sort.
  */
 module.exports.isSortValid = function(input) {
-  if (isEmpty(input)) {
-    return DEFAULT_SORT;
-  }
-
   try {
     const parsed = parseSort(input);
+
+    if (isEmpty(parsed)) {
+      return DEFAULT_SORT;
+    }
 
     if (_.isArray(parsed) && _.every(parsed, isValueOkForSortArray)) {
       return parsed;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -451,6 +451,10 @@ describe('mongodb-query-parser', function() {
       assert.equal(parser.isSortValid('[["foo", "bar"]]'), false);
       assert.equal(parser.isSortValid('[[123, -1]]'), false);
     });
+    it('should handle null and undefined', () => {
+      assert.equal(parser.isSortValid('null'), null);
+      assert.equal(parser.isSortValid('undefined'), null);
+    });
   });
 
   describe('skip', function() {


### PR DESCRIPTION
Unintentionally broke this behavior in #79, the fix parses incoming value before doing a isEmpty check so even when input is `"null"` or `"undefined"`, we handle it